### PR TITLE
Potential fix for code scanning alert no. 1: Cross-site scripting

### DIFF
--- a/src/main/java/org/weewelchie/strava/controller/GeminiController.java
+++ b/src/main/java/org/weewelchie/strava/controller/GeminiController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.HtmlUtils;
 import org.weewelchie.strava.client.StravaRestClient;
 import org.weewelchie.strava.data.beans.StravaActivity;
 import org.weewelchie.strava.data.beans.StravaAthleteStats;
@@ -83,6 +84,7 @@ public class GeminiController {
     }
 
     private String formatAsHtml(String title, String markdownContent) {
+        String safeTitle = HtmlUtils.htmlEscape(title == null ? "" : title);
         String base64Content = markdownContent == null ? "" : Base64.getEncoder()
                 .encodeToString(markdownContent.getBytes(StandardCharsets.UTF_8));
 
@@ -213,6 +215,6 @@ public class GeminiController {
             </script>
         </body>
         </html>
-        """.replace("{{title}}", title).replace("{{content}}", base64Content);
+        """.replace("{{title}}", safeTitle).replace("{{content}}", base64Content);
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/welchie/stravastats/security/code-scanning/1](https://github.com/welchie/stravastats/security/code-scanning/1)

The best fix is to apply **contextual HTML escaping** to the user-controlled `title` before putting it into the HTML string template. This preserves existing behavior while preventing markup/script injection.

In `src/main/java/org/weewelchie/strava/controller/GeminiController.java`, update `formatAsHtml` so it:
1. Computes an escaped version of `title` (e.g., via Spring’s `HtmlUtils.htmlEscape`).
2. Uses that escaped value in the final template replacement for `{{title}}`.
3. Leaves `base64Content` behavior unchanged.

Also add the required import:
- `org.springframework.web.util.HtmlUtils`

This is the minimal, safest change in the shown code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
